### PR TITLE
Update to 63.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,10 +15,10 @@ source:
     - patches/0019-Use-ranlib-from-env-if-env-variable-is-set.patch
     - patches/0012-Disable-new-dtags-in-unixccompiler.py.patch
     - patches/0021-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
-    # - patches/0006-Win32-Fixes-for-Windows-GCC-interop-needed-by-RPy2-a.patch
+    - patches/0006-Win32-Fixes-for-Windows-GCC-interop-needed-by-RPy2-a.patch
     # distutils patches from pypy3.6-feedstock
     - patches/0035-pypy-distutils-scheme.patch   # [win or py>37]
-
+    - patches/0010-Add-support-for-_CONDA_PYTHON_SYSCONFIGDATA_NAME-if-.patch
 build:
   number: 0
   skip: True               # [py<37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "61.2.0" %}
+{% set version = "63.4.1" %}
 
 # make sure to set CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 environ-variable before building it
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/setuptools/setuptools-{{ version }}.tar.gz
-  sha256: c3d4e2ab578fbf83775755cd76dae73627915a22832cf4ea5de895978767833b
+  sha256: 7c7854ee1429a240090297628dc9f75b35318d193537968e2dc14010ee2f5bca
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - patches/0002-disable-downloads-inside-conda-build.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - patches/0019-Use-ranlib-from-env-if-env-variable-is-set.patch
     - patches/0012-Disable-new-dtags-in-unixccompiler.py.patch
     - patches/0021-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
-    - patches/0006-Win32-Fixes-for-Windows-GCC-interop-needed-by-RPy2-a.patch
+    # - patches/0006-Win32-Fixes-for-Windows-GCC-interop-needed-by-RPy2-a.patch
     # distutils patches from pypy3.6-feedstock
     - patches/0035-pypy-distutils-scheme.patch   # [win or py>37]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - patches/0006-Win32-Fixes-for-Windows-GCC-interop-needed-by-RPy2-a.patch
     # distutils patches from pypy3.6-feedstock
     - patches/0035-pypy-distutils-scheme.patch   # [win or py>37]
-    - patches/0010-Add-support-for-_CONDA_PYTHON_SYSCONFIGDATA_NAME-if-.patch
+
 build:
   number: 0
   skip: True               # [py<37]

--- a/recipe/patches/0006-Win32-Fixes-for-Windows-GCC-interop-needed-by-RPy2-a.patch
+++ b/recipe/patches/0006-Win32-Fixes-for-Windows-GCC-interop-needed-by-RPy2-a.patch
@@ -1,3 +1,12 @@
+From 4c935f04b47027b4cc15b7bb899e03eab41d34bf Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Wed, 16 Aug 2017 12:23:02 +0100
+Subject: [PATCH 06/30] Win32: Fixes for Windows GCC interop needed by RPy2 and
+ CVXOPT
+
+We must pass -DMS_WIN32 or -DMS_WIN64
+---
+
 index 2c6dbae..2b88a22 100644
 --- a/setuptools/_distutils/cygwinccompiler.py
 +++ b/setuptools/_distutils/cygwinccompiler.py

--- a/recipe/patches/0006-Win32-Fixes-for-Windows-GCC-interop-needed-by-RPy2-a.patch
+++ b/recipe/patches/0006-Win32-Fixes-for-Windows-GCC-interop-needed-by-RPy2-a.patch
@@ -1,25 +1,17 @@
-From 4c935f04b47027b4cc15b7bb899e03eab41d34bf Mon Sep 17 00:00:00 2001
-From: Ray Donnelly <mingw.android@gmail.com>
-Date: Wed, 16 Aug 2017 12:23:02 +0100
-Subject: [PATCH 06/30] Win32: Fixes for Windows GCC interop needed by RPy2 and
- CVXOPT
+index 2c6dbae..2b88a22 100644
+--- a/setuptools/_distutils/cygwinccompiler.py
++++ b/setuptools/_distutils/cygwinccompiler.py
+@@ -322,13 +322,15 @@ class Mingw32CCompiler(CygwinCCompiler):
+         if is_cygwincc(self.cc):
+             raise CCompilerError('Cygwin gcc cannot be used with --compiler=mingw32')
 
-We must pass -DMS_WIN32 or -DMS_WIN64
----
- Lib/distutils/cygwinccompiler.py | 10 +++++++---
- 1 file changed, 7 insertions(+), 3 deletions(-)
-
-diff --git a/setuptools/_distutils/cygwinccompiler.py b/setuptools/_distutils/cygwinccompiler.py
-index e6c790118b..d4337669e3 100644
---- a/setuptools/_distutils/cygwinccompiler.py	2022-04-04 14:10:21.103272716 +0300
-+++ b/setuptools/_distutils/cygwinccompiler.py	2022-04-04 14:10:32.087468154 +0300
-@@ -276,9 +276,13 @@
-             raise CCompilerError(
-                 'Cygwin gcc cannot be used with --compiler=mingw32')
- 
--        self.set_executables(compiler='%s -O -Wall' % self.cc,
--                             compiler_so='%s -mdll -O -Wall' % self.cc,
--                             compiler_cxx='%s -O -Wall' % self.cxx,
+-        self.set_executables(
+-            compiler='%s -O -Wall' % self.cc,
+-            compiler_so='%s -mdll -O -Wall' % self.cc,
+-            compiler_cxx='%s -O -Wall' % self.cxx,
+-            linker_exe='%s' % self.cc,
+-            linker_so='{} {}'.format(self.linker_dll, shared_option),
+-        )
 +        if sys.maxsize == 2**31 - 1:
 +            ms_win=' -DMS_WIN32'
 +        else:
@@ -27,6 +19,8 @@ index e6c790118b..d4337669e3 100644
 +        self.set_executables(compiler='%s -O -Wall %s' % (self.cc, ms_win),
 +                             compiler_so='%s -mdll -O -Wall %s' % (self.cc, ms_win),
 +                             compiler_cxx='%s -O -Wall %s' % (self.cxx, ms_win),
-                              linker_exe='%s' % self.cc,
-                              linker_so='%s %s'
-                                         % (self.linker_dll, shared_option))
++                             linker_exe='%s' % self.cc,
++                             linker_so='%s %s' % (self.linker_dll, shared_option))
+
+         # Maybe we should also append -mthreads, but then the finished
+         # dlls need another dll (mingwm10.dll see Mingw32 docs)

--- a/recipe/patches/0010-Add-support-for-_CONDA_PYTHON_SYSCONFIGDATA_NAME-if-.patch
+++ b/recipe/patches/0010-Add-support-for-_CONDA_PYTHON_SYSCONFIGDATA_NAME-if-.patch
@@ -1,0 +1,16 @@
+diff --color -Naur setuptools-59.2.0.orig/setuptools/_distutils/sysconfig.py setuptools-59.2.0/setuptools/_distutils/sysconfig.py
+--- setuptools-59.2.0.orig/setuptools/_distutils/sysconfig.py	2021-11-18 22:13:45.000000000 -0300
++++ setuptools-59.2.0/setuptools/_distutils/sysconfig.py	2021-11-19 16:04:04.278279056 -0300
+@@ -478,10 +478,11 @@
+     # _sysconfigdata is generated at build time, see the sysconfig module
+     name = os.environ.get(
+         '_PYTHON_SYSCONFIGDATA_NAME',
++        os.environ.get('_CONDA_PYTHON_SYSCONFIGDATA_NAME',
+         _sysconfig_name_tmpl.format(
+             abi=sys.abiflags,
+             platform=sys.platform,
+-            multiarch=getattr(sys.implementation, '_multiarch', ''),
++            multiarch=getattr(sys.implementation, '_multiarch', '')),
+         ),
+     )
+     try:

--- a/recipe/patches/0012-Disable-new-dtags-in-unixccompiler.py.patch
+++ b/recipe/patches/0012-Disable-new-dtags-in-unixccompiler.py.patch
@@ -1,52 +1,48 @@
-From c23b6879c789beb899744592bbd5e13a2153c7f1 Mon Sep 17 00:00:00 2001
-From: Ray Donnelly <mingw.android@gmail.com>
-Date: Sun, 29 Apr 2018 16:10:42 +0100
-Subject: [PATCH 12/30] Disable new-dtags in unixccompiler.py
-
-They prevent isolation from system libraries and the HPC 'modules' system
-by giving precedence to LD_LIBRARY_PATH. We never want our libraries to
-be interposed by other libraries.
-
-The ELF spec. has comprehensive rpath support and new-dtags causes far
-more harm than good (for Anaconda Distribution at least). This may be a
-bit controversial I am convinced this is the right thing to do.
-
-Exclude this check from Windows though really we shouldn't have to as
-GNULD should be getting determined in a different way than from using
-sysconfig (which relates to the compiler used to build the interpreter
-itself, MSVC).
----
- Lib/distutils/tests/test_unixccompiler.py | 4 ++--
- Lib/distutils/unixccompiler.py            | 6 +++---
- 2 files changed, 5 insertions(+), 5 deletions(-)
-
 diff --git a/setuptools/_distutils/tests/test_unixccompiler.py b/setuptools/_distutils/tests/test_unixccompiler.py
-index eef702cf01..2d8d61df03 100644
---- a/setuptools/_distutils/tests/test_unixccompiler.py	2022-03-28 00:12:42.000000000 +0300
-+++ b/setuptools/_distutils/tests/test_unixccompiler.py	2022-04-04 13:57:01.224072490 +0300
-@@ -151,7 +151,7 @@
-             elif v == 'GNULD':
+index 4be4ff2..bb8926d 100644
+--- a/setuptools/_distutils/tests/test_unixccompiler.py
++++ b/setuptools/_distutils/tests/test_unixccompiler.py
+@@ -155,7 +155,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
                  return 'yes'
+
          sysconfig.get_config_var = gcv
--        self.assertEqual(self.cc.rpath_foo(), '-Wl,--enable-new-dtags,-R/foo')
-+        self.assertEqual(self.cc.rpath_foo(), '-Wl,-R/foo')
- 
+-        assert self.cc.rpath_foo() == '-Wl,--enable-new-dtags,-R/foo'
++        assert self.cc.rpath_foo() == '-Wl,-R/foo'
+
+         def gcv(v):
+             if v == 'CC':
+@@ -164,7 +164,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
+                 return 'yes'
+
+         sysconfig.get_config_var = gcv
+-        assert self.cc.rpath_foo() == '-Wl,--enable-new-dtags,-R/foo'
++        assert self.cc.rpath_foo() == '-Wl,-R/foo'
+
          # GCC non-GNULD
          sys.platform = 'bar'
-@@ -161,7 +161,7 @@
-             elif v == 'GNULD':
-                 return 'no'
+@@ -189,7 +189,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
+                 return 'yes'
+
          sysconfig.get_config_var = gcv
--        self.assertEqual(self.cc.rpath_foo(), '-Wl,-R/foo')
-+        self.assertEqual(self.cc.rpath_foo(), '-Wl,--disable-new-dtags,-R/foo')
- 
-         # GCC GNULD with fully qualified configuration prefix
-         # see #7617
+-        assert self.cc.rpath_foo() == '-Wl,--enable-new-dtags,-R/foo'
++        assert self.cc.rpath_foo() == '-Wl,-R/foo'
+
+         # non-GCC GNULD
+         sys.platform = 'bar'
+@@ -201,7 +201,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
+                 return 'yes'
+
+         sysconfig.get_config_var = gcv
+-        assert self.cc.rpath_foo() == '-Wl,--enable-new-dtags,-R/foo'
++        assert self.cc.rpath_foo() == '-Wl,-R/foo'
+
+         # non-GCC non-GNULD
+         sys.platform = 'bar'
 diff --git a/setuptools/_distutils/unixccompiler.py b/setuptools/_distutils/unixccompiler.py
-index 84a421767d..12a9f777fe 100644
---- a/setuptools/_distutils/unixccompiler.py	2022-03-28 00:12:42.000000000 +0300
-+++ b/setuptools/_distutils/unixccompiler.py	2022-04-04 14:00:08.035874005 +0300
-@@ -294,12 +294,12 @@
+index 4ab771a..bc1c584 100644
+--- a/setuptools/_distutils/unixccompiler.py
++++ b/setuptools/_distutils/unixccompiler.py
+@@ -315,10 +315,10 @@ class UnixCCompiler(CCompiler):
          # For all compilers, `-Wl` is the presumed way to
          # pass a compiler option to the linker and `-R` is
          # the way to pass an RPATH.
@@ -55,10 +51,6 @@ index 84a421767d..12a9f777fe 100644
              # GNU ld needs an extra option to get a RUNPATH
              # instead of just an RPATH.
 -            return "-Wl,--enable-new-dtags,-R" + dir
--        else:
++            return "-Wl,-R" + dir
+         else:
              return "-Wl,-R" + dir
-+        else:
-+            return "-Wl,--disable-new-dtags,-R" + dir
- 
-     def library_option(self, lib):
-         return "-l" + lib

--- a/recipe/patches/0012-Disable-new-dtags-in-unixccompiler.py.patch
+++ b/recipe/patches/0012-Disable-new-dtags-in-unixccompiler.py.patch
@@ -1,3 +1,22 @@
+From c23b6879c789beb899744592bbd5e13a2153c7f1 Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Sun, 29 Apr 2018 16:10:42 +0100
+Subject: [PATCH 12/30] Disable new-dtags in unixccompiler.py
+
+They prevent isolation from system libraries and the HPC 'modules' system
+by giving precedence to LD_LIBRARY_PATH. We never want our libraries to
+be interposed by other libraries.
+
+The ELF spec. has comprehensive rpath support and new-dtags causes far
+more harm than good (for Anaconda Distribution at least). This may be a
+bit controversial I am convinced this is the right thing to do.
+
+Exclude this check from Windows though really we shouldn't have to as
+GNULD should be getting determined in a different way than from using
+sysconfig (which relates to the compiler used to build the interpreter
+itself, MSVC).
+---
+
 diff --git a/setuptools/_distutils/tests/test_unixccompiler.py b/setuptools/_distutils/tests/test_unixccompiler.py
 index 4be4ff2..bb8926d 100644
 --- a/setuptools/_distutils/tests/test_unixccompiler.py

--- a/recipe/patches/0019-Use-ranlib-from-env-if-env-variable-is-set.patch
+++ b/recipe/patches/0019-Use-ranlib-from-env-if-env-variable-is-set.patch
@@ -1,22 +1,13 @@
-From e3eae5df830e7c53d0d6fd38b55bff648aeec37a Mon Sep 17 00:00:00 2001
-From: Isuru Fernando <isuruf@gmail.com>
-Date: Sun, 3 Nov 2019 15:09:45 -0600
-Subject: [PATCH 19/30] Use ranlib from env if env variable is set
-
----
- Lib/distutils/sysconfig.py | 3 +++
- 1 file changed, 3 insertions(+)
-
 diff --git a/setuptools/_distutils/sysconfig.py b/setuptools/_distutils/sysconfig.py
---- a/setuptools/_distutils/sysconfig.py	2022-04-04 13:48:32.576106442 +0300
-+++ b/setuptools/_distutils/sysconfig.py	2022-04-04 13:53:45.651791165 +0300
-@@ -265,6 +265,9 @@
+index aae9c1b..469ed85 100644
+--- a/setuptools/_distutils/sysconfig.py
++++ b/setuptools/_distutils/sysconfig.py
+@@ -339,6 +339,9 @@ def customize_compiler(compiler):  # noqa: C901
          if 'RANLIB' in os.environ and compiler.executables.get('ranlib', None):
              compiler.set_executables(ranlib=os.environ['RANLIB'])
- 
+
 +        if 'RANLIB' in os.environ and 'ranlib' in compiler.executables:
 +            compiler.set_executables(ranlib=os.environ['RANLIB'])
 +
          compiler.shared_lib_extension = shlib_suffix
- 
- 
+

--- a/recipe/patches/0019-Use-ranlib-from-env-if-env-variable-is-set.patch
+++ b/recipe/patches/0019-Use-ranlib-from-env-if-env-variable-is-set.patch
@@ -1,3 +1,10 @@
+From e3eae5df830e7c53d0d6fd38b55bff648aeec37a Mon Sep 17 00:00:00 2001
+From: Isuru Fernando <isuruf@gmail.com>
+Date: Sun, 3 Nov 2019 15:09:45 -0600
+Subject: [PATCH 19/30] Use ranlib from env if env variable is set
+
+---
+
 diff --git a/setuptools/_distutils/sysconfig.py b/setuptools/_distutils/sysconfig.py
 index aae9c1b..469ed85 100644
 --- a/setuptools/_distutils/sysconfig.py

--- a/recipe/patches/0021-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
+++ b/recipe/patches/0021-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
@@ -9,28 +9,31 @@ Subject: [PATCH 21/30] Add /d1trimfile:%SRC_DIR% to make pdbs more relocatable
 
 diff --git a/setuptools/_distutils/_msvccompiler.py b/setuptools/_distutils/_msvccompiler.py
 index af8099a407..8f73453a6c 100644
---- a/setuptools/_distutils/_msvccompiler.py	2022-04-04 14:03:00.035200972 +0300
-+++ b/setuptools/_distutils/_msvccompiler.py	2022-04-04 14:03:07.339339379 +0300
-@@ -350,6 +350,13 @@
+--- a/setuptools/_distutils/_msvccompiler.py
++++ b/setuptools/_distutils/_msvccompiler.py
+@@ -346,6 +346,13 @@ class MSVCCompiler(CCompiler) :
                  # without asking the user to browse for it
                  src = os.path.abspath(src)
- 
+
 +            # Anaconda/conda-forge customisation, we want our pdbs to be
 +            # relocatable:
 +            # https://developercommunity.visualstudio.com/comments/623156/view.html
 +            d1trimfile_opts = []
-+            if 'SRC_DIR' in os.environ:
++            if 'SRC_DIR' in os.environ and os.path.basename(self.cc) == "cl.exe":
 +                d1trimfile_opts.append("/d1trimfile:" + os.environ['SRC_DIR'])
 +
              if ext in self._c_extensions:
                  input_opt = "/Tc" + src
              elif ext in self._cpp_extensions:
-@@ -394,7 +401,7 @@
+@@ -390,7 +397,7 @@ class MSVCCompiler(CCompiler) :
                  raise CompileError("Don't know how to compile {} to {}"
                                     .format(src, obj))
- 
+
 -            args = [self.cc] + compile_opts + pp_opts
 +            args = [self.cc] + compile_opts + pp_opts + d1trimfile_opts
              if add_cpp_opts:
                  args.append('/EHsc')
              args.append(input_opt)
+--
+2.23.0
+

--- a/recipe/patches/0035-pypy-distutils-scheme.patch
+++ b/recipe/patches/0035-pypy-distutils-scheme.patch
@@ -1,39 +1,53 @@
-# Branch conda
-# Node ID 85c317f36cd8fc1962c1776a6cfb1df3572c518c
-# Parent  e9052b361691a2de3cfb86712ecd4609ac3aff12
-conda schema fixes for distutils
-
-diff -urN a/setuptools/_distutils/command/install.py b/setuptools/_distutils/command/install.py
---- a/setuptools/_distutils/command/install.py	2022-03-28 00:12:42.000000000 +0300
-+++ b/setuptools/_distutils/command/install.py	2022-04-04 14:15:58.037194406 +0300
-@@ -48,19 +48,13 @@
-         },
+diff --git a/setuptools/_distutils/command/install.py b/setuptools/_distuti
+ls/command/install.py
+index a38cddc..f086a7d 100644
+--- a/setuptools/_distutils/command/install.py
++++ b/setuptools/_distutils/command/install.py
+@@ -51,20 +51,14 @@ INSTALL_SCHEMES = {
+     },
      'nt': WINDOWS_SCHEME,
      'pypy': {
 -        'purelib': '{base}/site-packages',
 -        'platlib': '{base}/site-packages',
 -        'headers': '{base}/include/{dist_name}',
-+        'purelib': '$base/lib/python$py_version_short/site-packages',          
-+        'platlib': '$platbase/lib/python$py_version_short/site-packages',      
-+        'headers': '$base/include/python$py_version_short$abiflags/$dist_name',
++        'purelib': '$base/lib/python$py_version_short/site-packages',
++        'platlib': '$platbase/lib/python$py_version_short/site-packages',
++        'headers': '$base/include/python$py_version_short$abiflags/$dist_n
+ame',
          'scripts': '{base}/bin',
-         'data'   : '{base}',
-         },
+         'data': '{base}',
+     },
 -    'pypy_nt': {
 -        'purelib': '{base}/site-packages',
 -        'platlib': '{base}/site-packages',
 -        'headers': '{base}/include/{dist_name}',
 -        'scripts': '{base}/Scripts',
--        'data'   : '{base}',
--        },
+-        'data': '{base}',
+-    },
+-}
 +    'pypy_nt': WINDOWS_SCHEME,
-     }
- 
++     }
+
  # user site schemes
-diff -urN a/setuptools/_distutils/sysconfig.py b/setuptools/_distutils/sysconfig.py
---- a/setuptools/_distutils/sysconfig.py	2022-04-04 15:04:48.747619631 +0300
-+++ b/setuptools/_distutils/sysconfig.py	2022-04-04 15:02:59.555429627 +0300
-@@ -152,23 +152,19 @@
+ if HAS_USER_SITE:
+
+diff --git a/setuptools/_distutils/sysconfig.py b/setuptools/_distutils/sys
+config.py
+index aae9c1b..ae2adec 100644
+--- a/setuptools/_distutils/sysconfig.py
++++ b/setuptools/_distutils/sysconfig.py
+@@ -118,6 +118,10 @@ def get_python_inc(plat_specific=0, prefix=None):
+     If 'prefix' is supplied, use it instead of sys.base_prefix or
+     sys.base_exec_prefix -- i.e., ignore 'plat_specific'.
+     """
++
++
++
++
+     default_prefix = BASE_EXEC_PREFIX if plat_specific else BASE_PREFIX
+     resolved_prefix = prefix if prefix is not None else default_prefix
+     try:
+@@ -210,23 +214,19 @@ def get_python_lib(plat_specific=0, standard_lib=0, prefix=None):
      If 'prefix' is supplied, use it instead of sys.base_prefix or
      sys.base_exec_prefix -- i.e., ignore 'plat_specific'.
      """
@@ -42,7 +56,7 @@ diff -urN a/setuptools/_distutils/sysconfig.py b/setuptools/_distutils/sysconfig
 +            prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
 +        else:
 +            prefix = plat_specific and EXEC_PREFIX or PREFIX
- 
+
      if IS_PYPY and sys.version_info < (3, 8):
 -        # PyPy-specific schema
 -        if prefix is None:
@@ -51,9 +65,9 @@ diff -urN a/setuptools/_distutils/sysconfig.py b/setuptools/_distutils/sysconfig
          if standard_lib:
              return os.path.join(prefix, "lib-python", sys.version[0])
 -        return os.path.join(prefix, 'site-packages')
- 
+
      early_prefix = prefix
- 
+
 -    if prefix is None:
 -        if standard_lib:
 -            prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX

--- a/recipe/patches/0035-pypy-distutils-scheme.patch
+++ b/recipe/patches/0035-pypy-distutils-scheme.patch
@@ -1,5 +1,4 @@
-diff --git a/setuptools/_distutils/command/install.py b/setuptools/_distuti
-ls/command/install.py
+diff --git a/setuptools/_distutils/command/install.py b/setuptools/_distutils/command/install.py
 index a38cddc..f086a7d 100644
 --- a/setuptools/_distutils/command/install.py
 +++ b/setuptools/_distutils/command/install.py
@@ -12,8 +11,7 @@ index a38cddc..f086a7d 100644
 -        'headers': '{base}/include/{dist_name}',
 +        'purelib': '$base/lib/python$py_version_short/site-packages',
 +        'platlib': '$platbase/lib/python$py_version_short/site-packages',
-+        'headers': '$base/include/python$py_version_short$abiflags/$dist_n
-ame',
++        'headers': '$base/include/python$py_version_short$abiflags/$dist_name',
          'scripts': '{base}/bin',
          'data': '{base}',
      },

--- a/recipe/patches/0035-pypy-distutils-scheme.patch
+++ b/recipe/patches/0035-pypy-distutils-scheme.patch
@@ -1,3 +1,8 @@
+# Branch conda
+# Node ID 85c317f36cd8fc1962c1776a6cfb1df3572c518c
+# Parent  e9052b361691a2de3cfb86712ecd4609ac3aff12
+conda schema fixes for distutils
+
 diff --git a/setuptools/_distutils/command/install.py b/setuptools/_distutils/command/install.py
 index a38cddc..f086a7d 100644
 --- a/setuptools/_distutils/command/install.py


### PR DESCRIPTION
Version bump to 63.4.1.
- updated sha256
- added and updated patches

Reviewed the upstream changelog and found two breaking changes since the last update (61.2.0).
- https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6300
- https://github.com/pypa/setuptools/blob/main/CHANGES.rst#breaking-changes-1

We determined that these changes should not impact us.