### PR TITLE
Build v49.1.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-channels:
-  mesters_org: scipy
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,6 @@
 channels:
   mesters_org: scipy
 build_parameters:
-  - error-overlinking
-  - error-overdepending
-  - suppress-variables
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  mesters_org: scipy
+build_parameters:
+  - error-overlinking
+  - error-overdepending
+  - suppress-variables

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "61.2.0" %}
+{% set version = "49.1.3" %}
 
 # make sure to set CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 environ-variable before building it
 package:
@@ -6,18 +6,13 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/s/setuptools/setuptools-{{ version }}.tar.gz
-  sha256: c3d4e2ab578fbf83775755cd76dae73627915a22832cf4ea5de895978767833b
+  url: https://pypi.io/packages/source/s/setuptools/setuptools-{{ version }}.zip
+  sha256: ea484041dc6495c4ee74dd578470866e3043f6d1c998cfafbdb1f668f1768284
   patches:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - patches/0002-disable-downloads-inside-conda-build.patch
     # distutils patches from python-feedstock
-    - patches/0019-Use-ranlib-from-env-if-env-variable-is-set.patch
-    - patches/0012-Disable-new-dtags-in-unixccompiler.py.patch
     - patches/0021-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
-    - patches/0006-Win32-Fixes-for-Windows-GCC-interop-needed-by-RPy2-a.patch
-    # distutils patches from pypy3.6-feedstock
-    - patches/0035-pypy-distutils-scheme.patch   # [win or py>37]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,6 @@ about:
     designed to facilitate packaging Python projects.
   doc_url: https://setuptools.pypa.io/en/latest/
   dev_url: https://github.com/pypa/setuptools
-  doc_source_url: https://github.com/pypa/setuptools/tree/master/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,9 @@ about:
   dev_url: https://github.com/pypa/setuptools
 
 extra:
+  skip-lints:
+    - missing_wheel
+    - missing_python_build_tool
   recipe-maintainers:
     - jakirkham
     - msarahan

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,10 @@ requirements:
     - wincertstore  >=0.2  # [win]
 
 test:
+  requires:
+    - pip
+  commands:
+    - pip check
   imports:
     - setuptools
     - pkg_resources


### PR DESCRIPTION
setuptools v49.1.3 --> [numpy 1.19.5](https://github.com/AnacondaRecipes/numpy-feedstock/pull/63) --> [scipy 1.10.0](https://github.com/AnacondaRecipes/scipy-feedstock/pull/23)

Jira ticket: https://anaconda.atlassian.net/jira/software/c/projects/PKG/issues/PKG-1216
Upstream: https://github.com/pypa/setuptools/tree/v49.1.3

This version of `setuptools` is required to compile `numpy 1.19.5` on Windows.