### PR TITLE
Setuptools 60.9.3 exact version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,3 +61,8 @@ extra:
     - ocefpaf
     - nicoddemus
     - isuruf
+  skip-lints:
+    # skip linter's checks for wheel and python build tool: not there to avoid cyclic dependencies
+    - missing_wheel
+    - missing_python_build_tool
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "setuptools" %}
-{% set version = "66.0.0" %}
+{% set version = "60.9.3" %}
 {% set build = "0" %}
-{% set checksum = "bd6eb2d6722568de6d14b87c44a96fac54b2a45ff5e940e639979a3d1792adb6" %}
+{% set checksum = "2347b2b432c891a863acadca2da9ac101eae6169b1d3dfee2ec605ecd50dbfe5" %}
 
 # make sure to set CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 environ-variable before building it
 package:
@@ -15,7 +15,9 @@ source:
     # Modify setuptools to fail if used in conda build (encourage people to add all deps in meta.yaml).
     - patches/0002-disable-downloads-inside-conda-build.patch
     # distutils patches from python-feedstock
+    - patches/0012-Disable-new-dtags-in-unixccompiler.py.patch  # [py<=39]
     - patches/0021-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
+    - patches/0010-Add-support-for-_CONDA_PYTHON_SYSCONFIGDATA_NAME-if-.patch  # [py<=39 and python_impl=="cpython"]
 
 build:
   number: 0

--- a/recipe/patches/0010-Add-support-for-_CONDA_PYTHON_SYSCONFIGDATA_NAME-if-.patch
+++ b/recipe/patches/0010-Add-support-for-_CONDA_PYTHON_SYSCONFIGDATA_NAME-if-.patch
@@ -1,0 +1,16 @@
+diff --color -Naur setuptools-59.2.0.orig/setuptools/_distutils/sysconfig.py setuptools-59.2.0/setuptools/_distutils/sysconfig.py
+--- setuptools-59.2.0.orig/setuptools/_distutils/sysconfig.py	2021-11-18 22:13:45.000000000 -0300
++++ setuptools-59.2.0/setuptools/_distutils/sysconfig.py	2021-11-19 16:04:04.278279056 -0300
+@@ -478,10 +478,11 @@
+     # _sysconfigdata is generated at build time, see the sysconfig module
+     name = os.environ.get(
+         '_PYTHON_SYSCONFIGDATA_NAME',
++        os.environ.get('_CONDA_PYTHON_SYSCONFIGDATA_NAME',
+         _sysconfig_name_tmpl.format(
+             abi=sys.abiflags,
+             platform=sys.platform,
+-            multiarch=getattr(sys.implementation, '_multiarch', ''),
++            multiarch=getattr(sys.implementation, '_multiarch', '')),
+         ),
+     )
+     try:

--- a/recipe/patches/0012-Disable-new-dtags-in-unixccompiler.py.patch
+++ b/recipe/patches/0012-Disable-new-dtags-in-unixccompiler.py.patch
@@ -1,0 +1,67 @@
+From c23b6879c789beb899744592bbd5e13a2153c7f1 Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Sun, 29 Apr 2018 16:10:42 +0100
+Subject: [PATCH 12/30] Disable new-dtags in unixccompiler.py
+
+They prevent isolation from system libraries and the HPC 'modules' system
+by giving precedence to LD_LIBRARY_PATH. We never want our libraries to
+be interposed by other libraries.
+
+The ELF spec. has comprehensive rpath support and new-dtags causes far
+more harm than good (for Anaconda Distribution at least). This may be a
+bit controversial I am convinced this is the right thing to do.
+
+Exclude this check from Windows though really we shouldn't have to as
+GNULD should be getting determined in a different way than from using
+sysconfig (which relates to the compiler used to build the interpreter
+itself, MSVC).
+---
+ Lib/distutils/tests/test_unixccompiler.py | 4 ++--
+ Lib/distutils/unixccompiler.py            | 6 +++---
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/setuptools/_distutils/tests/test_unixccompiler.py b/setuptools/_distutils/tests/test_unixccompiler.py
+index eef702cf01..2d8d61df03 100644
+--- a/setuptools/_distutils/tests/test_unixccompiler.py
++++ b/setuptools/_distutils/tests/test_unixccompiler.py
+@@ -150,7 +150,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
+             elif v == 'GNULD':
+                 return 'yes'
+         sysconfig.get_config_var = gcv
+-        self.assertEqual(self.cc.rpath_foo(), '-Wl,--enable-new-dtags,-R/foo')
++        self.assertEqual(self.cc.rpath_foo(), '-Wl,-R/foo')
+ 
+         # GCC non-GNULD
+         sys.platform = 'bar'
+@@ -160,7 +160,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
+             elif v == 'GNULD':
+                 return 'no'
+         sysconfig.get_config_var = gcv
+-        self.assertEqual(self.cc.rpath_foo(), '-Wl,-R/foo')
++        self.assertEqual(self.cc.rpath_foo(), '-Wl,--disable-new-dtags,-R/foo')
+ 
+         # GCC GNULD with fully qualified configuration prefix
+         # see #7617
+diff --git a/setuptools/_distutils/unixccompiler.py b/setuptools/_distutils/unixccompiler.py
+index 84a421767d..12a9f777fe 100644
+--- a/setuptools/_distutils/unixccompiler.py
++++ b/setuptools/_distutils/unixccompiler.py
+@@ -249,12 +249,12 @@ class UnixCCompiler(CCompiler):
+         # For all compilers, `-Wl` is the presumed way to
+         # pass a compiler option to the linker and `-R` is
+         # the way to pass an RPATH.
+-        if sysconfig.get_config_var("GNULD") == "yes":
++        if sysconfig.get_config_var("GNULD") == "yes" or sys.platform == 'win32':
+             # GNU ld needs an extra option to get a RUNPATH
+             # instead of just an RPATH.
+-            return "-Wl,--enable-new-dtags,-R" + dir
+-        else:
+             return "-Wl,-R" + dir
++        else:
++            return "-Wl,--disable-new-dtags,-R" + dir
+
+     def library_option(self, lib):
+         return "-l" + lib
+-- 
+2.23.0
+

--- a/recipe/patches/0021-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
+++ b/recipe/patches/0021-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
@@ -11,10 +11,10 @@ diff --git a/setuptools/_distutils/_msvccompiler.py b/setuptools/_distutils/_msv
 index af8099a407..8f73453a6c 100644
 --- a/setuptools/_distutils/_msvccompiler.py
 +++ b/setuptools/_distutils/_msvccompiler.py
-@@ -367,6 +367,13 @@ class MSVCCompiler(CCompiler) :
+@@ -346,6 +346,13 @@ class MSVCCompiler(CCompiler) :
                  # without asking the user to browse for it
                  src = os.path.abspath(src)
-
+ 
 +            # Anaconda/conda-forge customisation, we want our pdbs to be
 +            # relocatable:
 +            # https://developercommunity.visualstudio.com/comments/623156/view.html
@@ -25,15 +25,14 @@ index af8099a407..8f73453a6c 100644
              if ext in self._c_extensions:
                  input_opt = "/Tc" + src
              elif ext in self._cpp_extensions:
-@@ -410,7 +417,7 @@ class MSVCCompiler(CCompiler) :
-                # how to handle this file?
-                raise CompileError(f"Don't know how to compile {src} to {obj}")
-
+@@ -390,7 +397,7 @@ class MSVCCompiler(CCompiler) :
+                 raise CompileError("Don't know how to compile {} to {}"
+                                    .format(src, obj))
+ 
 -            args = [self.cc] + compile_opts + pp_opts
 +            args = [self.cc] + compile_opts + pp_opts + d1trimfile_opts
              if add_cpp_opts:
                  args.append('/EHsc')
              args.append(input_opt)
---
+-- 
 2.23.0
-


### PR DESCRIPTION
[PKG-1821]

- old version
- update patches
- skip linter's checks for `wheel` and python build tool: not there to avoid cyclic dependencies (see [this conversation](https://anaconda.slack.com/archives/C04QPV5GWBW/p1685618169064419))


[PKG-1821]: https://anaconda.atlassian.net/browse/PKG-1821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ