### PR TITLE
setuptools 72.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "setuptools" %}
-{% set version = "69.5.1" %}
-{% set checksum = "6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987" %}
+{% set version = "72.1.0" %}
+{% set checksum = "8d243eff56d095e5817f796ede6ae32941278f542e0f941867cc05ae52b162ec" %}
 
 # make sure to set CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 environ-variable before building it
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ build:
   skip: True                # [py<38]
   missing_dso_whitelist:    # [win]
     - "$RPATH/MSVCR71.dll"  # [win]
+    - "$RPATH/MSVCR80.dll"  # [win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,9 @@ source:
 
 build:
   number: 0
-  skip: True               # [py<38]
+  skip: True                # [py<38]
+  missing_dso_whitelist:    # [win]
+    - "$RPATH/MSVCR71.dll"  # [win]
 
 requirements:
   build:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5387](https://anaconda.atlassian.net/browse/PKG-5387) 
- [Upstream repository](https://github.com/pypa/setuptools/tree/v72.1.0)
- Changelog https://github.com/pypa/setuptools/blob/v72.1.0/NEWS.rst
- Requirements: https://github.com/pypa/setuptools/blob/v72.1.0/pyproject.toml

### Explanation of changes:

- Add `$RPATH/MSVCR71.dll` and `$RPATH/MSVCR80.dll` to `missing_dso_whitelist` on `win` because of `ERROR (setuptools,Lib/site-packages/setuptools/_distutils/command/wininst-7.1.exe): $RPATH/MSVCR71.dll not found in packages, sysroot(s) nor the missing_dso_whitelist.`. The same happens in the `python` recipe, see https://github.com/AnacondaRecipes/python-feedstock/blob/master/recipe/meta.yaml#L148-L149

### Notes:

- Updating because CVE-2024-6345 affected `setuptools <70.0.0`
- This PR can break `backports` packages. See https://github.com/conda-forge/setuptools-feedstock/issues/351 and https://github.com/conda-forge/backports-feedstock/pull/7. To mitigate a possible impact I opened a PR https://github.com/AnacondaRecipes/backports-feedstock/pull/1

[PKG-5387]: https://anaconda.atlassian.net/browse/PKG-5387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ