### PR TITLE
PKG-8068: setuptools 52.0.0 py313 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   skip: true  # [py<35]
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
setuptools 52.0.0

**Destination channel:** defaults

### Links

- [PKG-8068]() 
- [Upstream repository](https://pypi.org/project/setuptools/52.0.0/)

### Explanation of changes:

- rebuild for py313


[PKG-8068]: https://anaconda.atlassian.net/browse/PKG-8068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ