### PR TITLE
setuptools 69.5.1 rebuild

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-aggregate_branch: 3.12
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,8 @@ source:
     - patches/0021-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
 
 build:
-  number: 0
-  skip: True               # [py<38]
+  number: 1
+  skip: True               # [py<310]
 
 requirements:
   build:


### PR DESCRIPTION
setuptools 69.5.1 

**Destination channel:** defaults

### Links

- [PKG-12570](https://anaconda.atlassian.net/browse/PKG-12570) 
- Upstream repo: https://github.com/pypa/setuptools
  - ...

### Explanation of changes:

- rebuilding to support python 3.13 and 3.14


[PKG-12570]: https://anaconda.atlassian.net/browse/PKG-12570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ